### PR TITLE
Add CCCogs to unapproved

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -59,6 +59,7 @@ approved:
   - https://github.com/Mister-42/mr42-cogs
   - https://github.com/japandotorg/Seina-Cogs
   - https://github.com/zhaobenny/bz-cogs
+  - https://github.com/ChaseCares/CCCogs
 
 # List of unapproved repos.
 # Will be parsed and categorized as "unapproved" by the indexer


### PR DESCRIPTION
I just completed my second cog and would like to be added to the unapproved list. I understand reviews aren't required, but I am open to any feedback, thank you!